### PR TITLE
フォントサイズを11ptに戻す

### DIFF
--- a/docs/docs.cls
+++ b/docs/docs.cls
@@ -1,4 +1,4 @@
-\LoadClass[line_length=45zw,number_of_lines=41]{jlreq}
+\LoadClass[fontsize=11pt,line_length=41zw,number_of_lines=37]{jlreq}
 \RequirePackage[bold-style=ISO,math-style=ISO]{unicode-math}
 \RequirePackage{color,etoolbox,luacode,luatexja-otf}
 \if"\directlua{tex.print(os.getenv("GITHUB_ACTIONS"))}"


### PR DESCRIPTION
#10 で間違って10ptにしてしまったため
`report`引数を指定すると章が追加されてしまうのでそれは指定しない