### PR TITLE
端末のブラウザとしてSafariを追加

### DIFF
--- a/docs/teian.tex
+++ b/docs/teian.tex
@@ -206,7 +206,7 @@
 		バックエンド & PHP（Laravel） & \\ \hline
 		フロントエンド & TypeScript & \\ \hline
 		端末OS & Android、Linux、Windows、iOS、macOS & \\ \hline
-		端末ブラウザ & Firefox、Google Chrome & \\ \hline
+		端末ブラウザ & Firefox、Google Chrome、Safari & \\ \hline
 		LLM & Google AI Studio & \\ \hline
 		地図 & OpenStreetMap & \\ \hline
 	\end{tabularx}


### PR DESCRIPTION
iOSとmacOSの標準のブラウザであり、FirefoxおよびGoogle Chromeとは異なる描画エンジン（WebKit）を使用しているため