### PR TITLE
自動レビュの日本語訳を表示するかの基準を変更

### DIFF
--- a/resources/ts/ci/reviewdog.ts
+++ b/resources/ts/ci/reviewdog.ts
@@ -130,7 +130,7 @@ type RdJsonDiagnostic = {
 		JSON.stringify({
 			diagnostics: await Promise.all(
 				diagnostics.map(async (d: RdJsonDiagnostic) => {
-					if (!d.message.includes("。")) {
+					if (!/[ぁ-ヿ]/.test(d.message)) {
 						d.message +=
 							(process.env.GITHUB_ACTIONS
 								? "\n**日本語訳**: "


### PR DESCRIPTION
仮名文字が含まれていないものに対してのみ表示するように
#90 で日本語に対して翻訳が働いてしまっていたので