### PR TITLE
textlintの漢数字を算用数字にするルールを無効化

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		],
 		"rules": {
 			"preset-ja-technical-writing": {
+				"arabic-kanji-numbers": false,
 				"ja-no-mixed-period": false,
 				"max-comma": false,
 				"max-kanji-continuous-len": false,


### PR DESCRIPTION
#114 の元凶なので