### PR TITLE
文書のリリースをおこなうGitHub Actionsのジョブを単一化

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -9,11 +9,9 @@ permissions:
   contents: write
 
 jobs:
-  get-name:
-    name: 文書の名前を取得
-    runs-on: ubuntu-latest
-    outputs:
-      name: ${{steps.get-name.outputs.name}}
+  latex:
+    name: LaTeX文書をコンパイル
+    runs-on: macos-latest
     steps:
       - id: get-name
         run: |
@@ -22,11 +20,6 @@ jobs:
           else
             exit 1
           fi
-  latex:
-    name: LaTeX文書をコンパイル
-    runs-on: macos-latest
-    needs: get-name
-    steps:
       - uses: actions/checkout@v5
       - run: sudo chown root /opt/homebrew/bin/gtar
       - run: sudo chmod u+s /opt/homebrew/bin/gtar
@@ -36,7 +29,7 @@ jobs:
           key: 0
           enableCrossOsArchive: true
       - run: sudo /usr/local/texlive/2025/bin/universal-darwin/tlmgr path add
-      - run: latexmk -lualatex ${{needs.get-name.outputs.name}}.tex
+      - run: latexmk -lualatex ${{steps.get-name.outputs.name}}.tex
         env:
           TZ: Asia/Tokyo
         working-directory: docs
@@ -44,4 +37,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          files: docs/${{needs.get-name.outputs.name}}.pdf
+          files: docs/${{steps.get-name.outputs.name}}.pdf


### PR DESCRIPTION
（Publicリポジトリだから関係ないけど）GitHub Actionsはジョブごとの実行時間を分単位で切り上げて料金の計算などに使用するようなので