### PR TITLE
"QRコード"を"二次元コード"に統一

### DIFF
--- a/docs/naibu.tex
+++ b/docs/naibu.tex
@@ -1136,7 +1136,7 @@ spotsテーブル（\cref{tab:db-spots}）は、
     e [shape=diamond];
 		a [label="二段階認証設定要求を受け取る"];
 		b [label="シークレットを生成"];
-		c [label="QRコードを生成して表示"];
+		c [label="二次元コードを生成して表示"];
 		d [label="利用者がワンタイムコードを入力"];
 		e [label="TOTPを検証"];
 		f [label="シークレットを保存し、設定完了画面を表示"];


### PR DESCRIPTION
Fix #445