### PR TITLE
フォントを明示的にゴシック体に

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -11,6 +11,7 @@
 * {
 	-ms-overflow-style: none; /* IE and Edge */
 	scrollbar-width: none; /* Firefox */
+	font-family: sans-serif;
 }
 body {
 	padding: 0;


### PR DESCRIPTION
Safariだと明朝体になるっぽいので